### PR TITLE
feat(Component heading)

### DIFF
--- a/src/components/Heading/Heading.stories.tsx
+++ b/src/components/Heading/Heading.stories.tsx
@@ -1,0 +1,52 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { Heading, HeadingProps } from './Heading'
+
+export default {
+  title: 'Components/Heading',
+  component: Heading,
+  args: {
+    children: 'Lorem ipsum.',
+    size: 'md',
+  },
+  argTypes: {
+    size: {
+      options: ['sm', 'md', 'lg'],
+      control: {
+        type: 'inline-radio',
+      },
+    },
+  },
+} as Meta<HeadingProps>
+
+export const Default: StoryObj = {}
+
+export const Small: StoryObj<HeadingProps> = {
+  args: {
+    size: 'sm',
+  },
+}
+
+export const Large: StoryObj<HeadingProps> = {
+  args: {
+    size: 'lg',
+  },
+}
+
+export const CustomComponent: StoryObj<HeadingProps> = {
+  args: {
+    asChild: true,
+    children: <h1>Heading with H1 tag</h1>,
+  },
+  argTypes: {
+    children: {
+      table: {
+        disable: true,
+      },
+    },
+    asChild: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+}

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import { clsx } from 'clsx'
+
+export interface HeadingProps {
+  size?: 'sm' | 'md' | 'lg'
+  children: ReactNode
+  asChild?: boolean
+}
+
+export function Heading({ asChild, children, size = 'md' }: HeadingProps) {
+  const Component = asChild ? Slot : 'h2'
+  return (
+    <Component
+      className={clsx('text-gray-100 font-bold font-sans', {
+        'text-lg': size === 'sm',
+        'text-xl': size === 'md',
+        'text-2xl': size === 'lg',
+      })}
+    >
+      {children}
+    </Component>
+  )
+}

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -1,0 +1,1 @@
+export { Heading } from './Heading'

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -35,10 +35,15 @@ export const Large: StoryObj<TextProps> = {
 export const CustomComponent: StoryObj<TextProps> = {
   args: {
     asChild: true,
-    children: <p>Testando</p>,
+    children: <p>Text with p tag</p>,
   },
   argTypes: {
     children: {
+      table: {
+        disable: true,
+      },
+    },
+    asChild: {
       table: {
         disable: true,
       },


### PR DESCRIPTION
## Task
- [X] Heading.tsx
- [X] Heading.stories.tsx

## Premise
Create the component to hold headings (h1, h2, h3, etc).

## Changes
- Added optional props `size` (that controls font-size) and `asChild` (to allow using `h1` and other HTML tags for headings)
- Added required prop `children` as ReactNode
- Created stories with Default, Small, Large, and CustomComponent variants
- Disabled `asChild` prop in Heading and Text stories of a CustomComponent variant

## Notes
- Installed `clsx` package to handle adding classes dynamically
- Installed `@radix-ui/react-slot'` package to give the component flexibility

## Concerns
N/A
